### PR TITLE
Draft support for an 'openldap' gather target & build step

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -179,7 +179,7 @@ with the -devel packages above; most are already present by default);
 == Phase 1: Gather Sources
 
  $ cd src/
- $ make -f ../mak/Makefile.gather [BLD={type}] [GRP=complete]
+ $ make -f ../mak/Makefile.gather [BLD={type}] [GRP=complete] [targets]
 
 BLD defines the build type: release - candidate - snapshot - bleed
 (case sensitive) where release is the default.
@@ -189,7 +189,10 @@ into the source tree, and generates a version and directory name manifest.
 
 This will gather all components if GRP=complete is specified, otherwise
 the linux system package sources of expat, lua, pcre, jansson, libxml2
-and zlib will not be gathered or compiled.
+and zlib will not be gathered or compiled. Two packages not included in
+the GRP=complete all target are the "openldap" library for the httpd ldap
+modules and the Tomcat "tcnative" connector. Add these explicitly to the
+targets list followed by the explicit "all" target, as desired. 
 
 Each component is designed for persistence, if from git or svn it performs
 a fetch / update, if from a most recent release package, it fetches and

--- a/mak/Makefile.build
+++ b/mak/Makefile.build
@@ -154,6 +154,38 @@ build-openssl: $(openssl_srcdir)/Makefile
 endif
 
 
+ifndef openldap_srcdir
+with_openldap=--without-ldap --without-lber
+enable_ldap=--disable-ldap --disable-authnz-ldap
+build-openldap:
+else
+with_openldap=--with-ldap-lib=$(DESTDIR)/lib --with-ldap-include=$(DESTDIR)/include --with-ldap=ldap --with-lber=lber
+enable_ldap=--enable-ldap --enable-authnz-ldap
+
+$(openldap_srcdir)/Makefile: build-openssl \
+			     $(SRCDIR)/$(openldap_srcdir)/configure
+	-mkdir $(openldap_srcdir) 2>/dev/null
+	cd $(openldap_srcdir) && \
+	  CPPFLAGS="-I$(DESTDIR)/include $(CPPFLAGS)" \
+	  LDFLAGS="-L$(DESTDIR)/lib $(LDFLAGS)" \
+	  $(SRCDIR)/$(openldap_srcdir)/configure \
+		 --with-tls=openssl \
+		 --without-cyrus-sasl \
+		 --disable-ldbm \
+		 --disable-sasl \
+		 --disable-slapd \
+		 --disable-slurpd \
+		 --prefix=$(DESTDIR) && \
+	cd ..
+
+build-openldap: $(openldap_srcdir)/Makefile
+	cd $(openldap_srcdir) && \
+	  make $(OPT) && \
+	  make $(OPT) install && \
+	cd ..
+endif
+
+
 # Disabing option checking here, so apr-util-1 options can be passed to apr-1
 # These options must be given to the monolithic apr-2 config
 ifndef apr_srcdir
@@ -221,11 +253,10 @@ $(aprutil_srcdir)/Makefile: build-openssl build-expat build-libxml2 \
 		 $(with_apr) \
 		 $(with_apriconv) \
 		 $(with_openssl) \
+		 $(with_openldap) \
 		 $(with_libxml2) \
 		 $(with_aprexpat) \
 		 --without-nss \
-		 --without-ldap \
-		 --without-lber \
 		 --with-crypto \
 		 --includedir=\$${prefix}/include \
 		 --prefix=$(DESTDIR) && \
@@ -435,9 +466,8 @@ $(curl_srcdir)/Makefile: build-openssl build-zlib build-brotli build-nghttp2 \
 		 --without-gssapi \
 		 --without-libidn2 \
 		 --without-librtmp \
-		 --without-ldap-lib \
-		 --without-lber-lib \
 		 --without-zsh-functions-dir \
+                 $(with_openldap) \
 		 --prefix=$(DESTDIR) && \
 	cd ..
 
@@ -453,12 +483,11 @@ endif
 # cgi for prefork configs, and authnz-fcgi and proxy-http2 for early adopters.
 #
 # Explicitly disabling dialup, echo and reflector as experimental/test
-# and disabling ldap because lber depends on openssl, and the system openssl
-# used by openldap conflicts with the most modern openssl in this build
 #
-$(httpd_srcdir)/Makefile: build-openssl build-apr build-aprutil \
+$(httpd_srcdir)/Makefile: build-openssl build-openldap \
 			  build-brotli build-jansson build-libxml2 \
 			  build-lua build-pcre build-zlib \
+			  build-apr build-aprutil \
 			  build-nghttp2 build-curl \
 			  $(SRCDIR)/$(httpd_srcdir)/configure
 	-mkdir $(httpd_srcdir) 2>/dev/null
@@ -475,14 +504,14 @@ $(httpd_srcdir)/Makefile: build-openssl build-apr build-aprutil \
 		 $(with_pcre) \
 		 $(with_zlib) \
 		 $(with_nghttp2) \
+		 $(with_openldap) \
 		 $(with_curl) \
 		 --enable-mods-shared=all \
 		 --enable-mpms-shared=all \
 		 --enable-load-all-modules \
 		 --enable-unixd=static \
 		 --enable-version=static \
-		 --disable-authnz-ldap \
-		 --disable-ldap \
+		 $(enable_ldap) \
 		 --disable-dialup \
 		 --disable-echo \
 		 --disable-reflector \

--- a/mak/Makefile.build
+++ b/mak/Makefile.build
@@ -494,7 +494,7 @@ $(httpd_srcdir)/Makefile: build-openssl build-openldap \
 	cd $(httpd_srcdir) && \
 	  $(SRCDIR)/$(httpd_srcdir)/configure \
 		 --prefix=$(DESTDIR) \
-		 $(with_openssl) \
+		 $(with_ssl) \
 		 $(with_apr) \
 		 $(with_aprutil) \
 		 $(with_brotli) \

--- a/mak/Makefile.gather
+++ b/mak/Makefile.gather
@@ -429,6 +429,37 @@ gather-curl-master: pre-manifest
 	echo curl_ver=$$curl_ver >>$(BLD)-manifest-vars
 
 
+gather-openldap-release: pre-manifest
+	openldap_srcpath=https://gpl.savoirfairelinux.net/pub/mirrors/openldap/openldap-release && \
+	openldap_pkg=`wget -q -O - $$openldap_srcpath/ | sed -n '/<a href="\(openldap-2\.4\.[0-9]*\.tgz\)"/{s#.*href="\(.*\)\.tgz".*#\1#;h};$$!b;g;p'` && \
+	openldap_ver=`echo $$openldap_pkg | sed 's#openldap-\(.*\)#\1#;'` && \
+	openldap_srcdir=openldap-$$openldap_ver && \
+	if test ! -f pkgs/$$openldap_pkg.tgz; then \
+	  cd pkgs && \
+	  wget -nv $$openldap_srcpath/$$openldap_pkg.tgz && \
+	  wget -nv $$openldap_srcpath/$$openldap_pkg.sha1 && \
+	  cd .. && \
+          tar -xzf pkgs/$$openldap_pkg.tgz; \
+	fi && \
+	echo openldap_srcpath=$$openldap_srcpath.tgz >>$(BLD)-manifest-vars && \
+	echo openldap_srcdir=$$openldap_srcdir >>$(BLD)-manifest-vars && \
+	echo openldap_ver=$$openldap_ver >>$(BLD)-manifest-vars
+
+gather-openldap-master: pre-manifest
+	openldap_srcpath=git://git.openldap.org/openldap.git && \
+	openldap_ver=2_4 && \
+	openldap_srcdir=openldap_$$openldap_ver && \
+	if test ! -d $$openldap_srcdir ; then \
+	  git clone -q -b OPENLDAP_REL_ENG_$$openldap_ver \
+		    $$openldap_srcpath $$openldap_srcdir; \
+	else \
+	  cd $$openldap_srcdir && git fetch -q && cd ..; \
+	fi && \
+	echo openldap_srcpath=$$openldap_srcpath >>$(BLD)-manifest-vars && \
+	echo openldap_srcdir=$$openldap_srcdir >>$(BLD)-manifest-vars && \
+	echo openldap_ver=$$openldap_ver >>$(BLD)-manifest-vars
+
+
 gather-expat-release: pre-manifest
 	expat_srcpath=https://github.com/libexpat/libexpat/releases && \
 	expat_ver=`wget -q -O - $$expat_srcpath | sed -n 's#^.*<a href=".*\/archive\/R_\(.*\)\.tar\.gz".*$$#\1#;t once;$$!b;:once;p;q;'` && \
@@ -716,10 +747,25 @@ gather-linux-bleed:   gather-core-bleed
 	LC_COLLATE=C sort < $(BLD)-manifest-vars.sav > $(BLD)-manifest-vars
 	rm $(BLD)-manifest-vars.sav
 
-
 ifeq "$(BLD)" "release"
 tcnative: gather-tcnative-release
+
+openldap: gather-openldap-release
+
+else ifeq "$(BLD)" "candidate"
+tcnative: gather-tcnative-release
+
+openldap: gather-openldap-release
+
+else ifeq "$(BLD)" "snapshot"
+tcnative: gather-tcnative-trunk
+
+openldap: gather-openldap-master
+
 else
 tcnative: gather-tcnative-trunk
+
+openldap:
+
 endif
 


### PR DESCRIPTION
The attached feature introduces support for

make -f ../mak/Makefile.gather openldap all

where openldap is an additional available target. The preconfig step should not be needed for openldap,
as the ./configure script is checked into the working repository. The test step is not possible as the server
side components of openldap are not built. The existing package step captures the resulting component.