### PR TITLE
curl 1.79 has changed up autocruft toggles again

### DIFF
--- a/mak/Makefile.build
+++ b/mak/Makefile.build
@@ -461,7 +461,7 @@ $(curl_srcdir)/Makefile: build-openssl build-zlib build-brotli build-nghttp2 \
 		 --without-nss \
 		 --without-axtls \
 		 --without-libpsl \
-		 --without-libmetalink \
+		 --without-libgsasl \
 		 --without-libssh2 \
 		 --without-gssapi \
 		 --without-libidn2 \


### PR DESCRIPTION
Catch up with losing libmetalink flag, and addition of undesired libgsasl

Signed-off-by: William A Rowe Jr <wrowe@vmware.com>